### PR TITLE
Fix the number of listings displayed by setting a limit

### DIFF
--- a/app/components/listings/Listings.tsx
+++ b/app/components/listings/Listings.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 import { useEffect, useState, useRef, useCallback } from 'react';
 
@@ -14,19 +13,20 @@ export default function Listings() {
   const [loading, setLoading] = useState(true);
   const [skeletonList, setSkeletonList] = useState<Array<number>>([]);
   const [list, setList] = useState<Array<Listing>>([]);
+  const dataLimit = 150;
 
   const fetchData = useCallback(async () => {
     setLoading(true);
     setSkeletonList(initialSkeletonList);
-    const newData = await fetchListings(list.length);
+    const newData = await fetchListings();
     setList((data) => data.concat(newData));
     setSkeletonList([]);
     setLoading(false);
-  }, [list.length]);
+  }, []);
 
   useEffect(() => {
     fetchData();
-  }, []);
+  }, [fetchData]);
 
   // Create a ref and attach it to a node at the end of the listings
   // We observe this node using IntersectionObserver and
@@ -37,7 +37,7 @@ export default function Listings() {
     const observingNode = observerTarget.current;
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting) {
+        if (entries[0].isIntersecting && list.length < dataLimit) {
           fetchData();
         }
       },
@@ -53,7 +53,7 @@ export default function Listings() {
         observer.unobserve(observingNode);
       }
     };
-  }, [observerTarget]);
+  }, [fetchData, list.length, observerTarget]);
 
   return (
     <div

--- a/app/utils/index.ts
+++ b/app/utils/index.ts
@@ -56,33 +56,30 @@ export const getGuid = () =>
     return v.toString(16);
   });
 
-type Fn = (index?: number) => Promise<Array<Listing>>;
+type Fn = () => Promise<Array<Listing>>;
 
-export const fetchListings: Fn = (startIndex = 0) => {
+export const fetchListings: Fn = () => {
   const promise: Promise<Listing[]> = new Promise((resolve) => {
     setTimeout(() => {
-      resolve(
-        startIndex >= 150
-          ? []
-          : Array.from({ length: 10 }).map((_, i) => {
-              return {
-                id: getGuid(),
-                host: {
-                  name: hostNames[randomInt(0, 5)],
-                  gender: genders[randomInt(0, 2)],
-                  age: randomInt(20, 80),
-                },
-                img: images[randomInt(0, 5)],
-                location: locations[randomInt(0, 5)],
-                availability: availabilities[randomInt(0, 5)],
-                price: prices[randomInt(0, 5)],
-                rating: ratings[randomInt(0, 5)],
-                distance: distances[randomInt(0, 5)],
-                category: categories[randomInt(0, 5)],
-                timeOfDay: 'night',
-              };
-            })
-      );
+      const data = Array.from({ length: 10 }).map((_, i) => {
+        return {
+          id: getGuid(),
+          host: {
+            name: hostNames[randomInt(0, 5)],
+            gender: genders[randomInt(0, 2)],
+            age: randomInt(20, 80),
+          },
+          img: images[randomInt(0, 5)],
+          location: locations[randomInt(0, 5)],
+          availability: availabilities[randomInt(0, 5)],
+          price: prices[randomInt(0, 5)],
+          rating: ratings[randomInt(0, 5)],
+          distance: distances[randomInt(0, 5)],
+          category: categories[randomInt(0, 5)],
+          timeOfDay: 'night',
+        };
+      });
+      resolve(data);
     }, randomInt(1, 3) * 1000);
   });
   return promise;


### PR DESCRIPTION
There is a bug with the fetchData fn in the Listings component. The fetchData calls the fetchListings which take an argument `startIndex` that is used to limit the data sent to the component.

However, the implementation was flawed and this PR aims to fix that.